### PR TITLE
Remove unused params in updateBranchProtection

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,11 +10,9 @@ tags: [
 before:
   - type: updateBranchProtection
     branch: master
-    required_status_checks: null
     enforce_admins: true
     required_pull_request_reviews:
       include_admins: true
-    restrictions: null
   - type: createIssue
     title: Getting Started with GitHub
     body: "01-welcome.md"


### PR DESCRIPTION
There were a few unused branch protection settings that conflict with the new schema validation. These are currently being set to `null`, but as that's the default we have no need to set them explicitly.