### PR TITLE
Fix markdown for landing page URL in markdown course

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ In this course, you’ll learn how to:
 - Use Markdown to add lists, images, and links in a comment or text file
 - Determine where and how to use Markdown in a GitHub repository
 
-This course has a dedicated message board on the [GitHub Community]({{ communityBoard }}) website. If you want to discuss this course with GitHub Trainers or other participants create a post over there. The message board can also be used to troubleshoot any issue you encounter while taking this course.
+This course has a dedicated message board on the <a href="{{ communityBoard }}">GitHub Community</a> website. If you want to discuss this course with GitHub Trainers or other participants create a post over there. The message board can also be used to troubleshoot any issue you encounter while taking this course.


### PR DESCRIPTION
This PR fixes a link that was not rendering properly and was reported in the [community forum](https://github.community/t5/GitHub-Learning-Lab/Course-quot-Communicating-using-Markdown-quot-Broken-markdown/m-p/22637/highlight/false#M767). 

cc @hectorsector @githubtraining/learning-engineering, markdown isn't working for links on the course home pages. Before fixing for all courses, I want to check that this isn't some other bug with Learning Lab that is causing this. 