### PR TITLE
Mark everywhere that URL needs fixed for pages site

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -67,11 +67,16 @@ steps:
           thePayload: '%payload%'
       - type: closeIssue
         issue: Getting Started with GitHub
+      - type: octokit
+        method: repos.getPages
+        owner: '%payload.repository.owner.login%'
+        repo: '%payload.repository.name%'
+        action_id: pagesUrl
       - type: respond
         issue: Getting Started with GitHub
         with: '02_close-issue.md'
         data:
-          url: 'https://%payload.repository.owner.login%.github.io/%payload.repository.name%' #TODO fix
+          url: '%actions.pagesUrl.data.html_url%'
           prUrl: '%actions.pr.data.html_url%'
 
   #3 - Add headers
@@ -108,10 +113,15 @@ steps:
         title: Introduce yourself to the world
         body: 04_add-image.md
         head: add-images-links
+      - type: octokit
+        method: repos.getPages
+        owner: '%payload.repository.owner.login%'
+        repo: '%payload.repository.name%'
+        action_id: pagesUrl
       - type: respond
         with: 04_next.md
         data:
-          url: 'https://%payload.repository.owner.login%.github.io/%payload.repository.name%' #TODO fix
+          url: '%actions.pagesUrl.data.html_url%'
           prUrl: '%actions.pr.data.html_url%'
 
   #5 - Add an image
@@ -167,10 +177,15 @@ steps:
         body: 07_pr-body.md
         action_id: pr
         head: add-lists-emphasis
+      - type: octokit
+        method: repos.getPages
+        owner: '%payload.repository.owner.login%'
+        repo: '%payload.repository.name%'
+        action_id: pagesUrl
       - type: respond
         with: 07_next.md
         data:
-          url: 'https://%payload.repository.owner.login%.github.io/%payload.repository.name%' #TODO fix
+          url: '%actions.pagesUrl.data.html_url%'
           prUrl: '%actions.pr.data.html_url%'
 
   #8 - Add a list
@@ -226,10 +241,15 @@ steps:
         action_id: issue
       - type: mergeBranch
         head: add-theme
+      - type: octokit
+        method: repos.getPages
+        owner: '%payload.repository.owner.login%'
+        repo: '%payload.repository.name%'
+        action_id: pagesUrl
       - type: respond
         with: 10_next.md
         data:
-          url: 'https://%payload.repository.owner.login%.github.io/%payload.repository.name%' #TODO fix
+          url: '%actions.pagesUrl.data.html_url%'
           issueUrl: '%actions.issue.data.html_url%'
       - type: octokit
         method: repos.edit


### PR DESCRIPTION
This pull request aims to fix the URLs for deployed pages sites, but since I'm not sure how to do that yet, the first commit just points out the location of those references so they'll be easy to change once we know how. 

cc @githubtraining/learning-engineering @githubtraining/trainers 