### PR TITLE
Replace link to Gists

### DIFF
--- a/responses/00_welcome.md
+++ b/responses/00_welcome.md
@@ -10,7 +10,7 @@ You can use Markdown most places around GitHub:
 
 - Comments in issues and pull requests (like this one!)
 - Files with the `.md` or `.markdown` extension
-- Sharing snippets of text in [Gists](https://gist.github.com/)
+- Sharing snippets of text in [Gists](https://help.github.com/en/articles/about-gists)
 
 For more information, see “[Writing on GitHub](https://help.github.com/categories/writing-on-github/)” in the _GitHub Help_.
 


### PR DESCRIPTION
What do you think about this strategy @brianamarie? The help article can be localized to the version of GHES. I don't see any way to get the Gist URL from the webhook. 

Closes #19.