### PR TITLE
Update repos.edit to repos.update

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -257,7 +257,7 @@ steps:
           url: '%actions.pagesUrl.data.html_url%'
           issueUrl: '%actions.issue.data.html_url%'
       - type: octokit
-        method: repos.edit
+        method: repos.update
         owner: '%payload.repository.owner.login%'
         repo: '%payload.repository.name%'
         name: '%payload.repository.name%'


### PR DESCRIPTION
This PR updates a deprecated Octokit method to use `repos.update()` instead of `repos.edit()`.